### PR TITLE
added some C++ links

### DIFF
--- a/Cpp/learn_cpp.md
+++ b/Cpp/learn_cpp.md
@@ -11,3 +11,9 @@
 *https://www.learncpp.com/*
 
 *https://practice.geeksforgeeks.org/courses/fork-cpp*
+
+*https://github.com/cpp-best-practices/cppbestpractices*
+
+*https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines*
+
+*https://isocpp.org/wiki/faq/*


### PR DESCRIPTION
I Have added some links into the [_learn C++_](https://github.com/shivanshsinghx365/Computer-Science-Resources/blob/76dfc8daa53a6e2f9fef51062b2460762e2b430f/Cpp/learn_cpp.md) section, namely:
- [C++ Best Practices](https://github.com/cpp-best-practices/cppbestpractices),
- [Cpp Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines),
- [ISO C++ faq](https://isocpp.org/wiki/faq/).