### PR TITLE
chore: use lychee action

### DIFF
--- a/.github/workflows/all_url_check.yml
+++ b/.github/workflows/all_url_check.yml
@@ -23,5 +23,5 @@ jobs:
            --verbose
            --no-progress
            '**/*.md'
-           fail: true
+          fail: true
 ...

--- a/.github/workflows/all_url_check.yml
+++ b/.github/workflows/all_url_check.yml
@@ -1,0 +1,26 @@
+---
+name: all_url_check
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  push:
+  schedule:
+    - cron: '10 1 * * 1'
+
+jobs:
+  run_lychee:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: run lychee-action
+        uses: lycheeverse/lychee-action@v1.5.1
+        with:
+          args: >
+           --verbose
+           --no-progress
+           fail: true
+...

--- a/.github/workflows/all_url_check.yml
+++ b/.github/workflows/all_url_check.yml
@@ -22,6 +22,7 @@ jobs:
           args: >
            --verbose
            --no-progress
+           --timeout 10
            '**/*.md'
           fail: true
 ...

--- a/.github/workflows/all_url_check.yml
+++ b/.github/workflows/all_url_check.yml
@@ -22,6 +22,6 @@ jobs:
           args: >
            --verbose
            --no-progress
-           **/*.md
+           '**/*.md'
            fail: true
 ...

--- a/.github/workflows/all_url_check.yml
+++ b/.github/workflows/all_url_check.yml
@@ -22,5 +22,6 @@ jobs:
           args: >
            --verbose
            --no-progress
+           **/*.md
            fail: true
 ...

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+https://codepen.io/


### PR DESCRIPTION
I added a workflow checking all of the links in the markdown files. I think we worst thing which can happen is to have dead links in a repository like this one. The workflow uses [lychee action](https://github.com/lycheeverse/lychee-action). The workflow will be triggered on every [push](https://github.com/vil02/Computer-Science-Resources/blob/e0079c0f6edb07e68df319c877c24ce9cbc91bf7/.github/workflows/all_url_check.yml#L7). It will also run [one per week on Mondays](https://github.com/vil02/Computer-Science-Resources/blob/e0079c0f6edb07e68df319c877c24ce9cbc91bf7/.github/workflows/all_url_check.yml#L9).

The page https://codepen.io/ was returning `403` code, therefore I [ignored it](https://github.com/vil02/Computer-Science-Resources/blob/e0079c0f6edb07e68df319c877c24ce9cbc91bf7/.lycheeignore).